### PR TITLE
Metaクラスの重複を修正

### DIFF
--- a/kita_lunch/app/models.py
+++ b/kita_lunch/app/models.py
@@ -36,8 +36,6 @@ class Tag(models.Model):
     class Meta:
         verbose_name = 'タグ'
         verbose_name_plural = 'タグ'
-
-    class Meta:
         db_table = 'Tag_info'
 
 from django.db import models
@@ -52,8 +50,6 @@ class Area(models.Model):
     class Meta:
         verbose_name = 'エリア'
         verbose_name_plural = 'エリア'
-
-    class Meta:
         db_table = 'Area_info'
 
 from django.db import models
@@ -76,8 +72,6 @@ class Store(models.Model):
     class Meta:
         verbose_name = '店舗'
         verbose_name_plural = '店舗'
-
-    class Meta:
         db_table = 'Store_info'
 
 


### PR DESCRIPTION
各クラスの中にMetaクラスが２回定義されていましたので、１つに統一しました。
こうしないと、2つ目のMetaクラスが1つ目を上書きしてしまいます。

例）
    class Meta:
        verbose_name = 'タグ'
        verbose_name_plural = 'タグ'
        db_table = 'Tag_info'
